### PR TITLE
Add SameSite finder workflow

### DIFF
--- a/passive/SameSiteFinder/README.md
+++ b/passive/SameSiteFinder/README.md
@@ -1,0 +1,5 @@
+# SameSiteFinder
+
+Author: @isacaya
+
+Extracts the names of issued cookies and their SameSite attributes to help identify entry points for CSRF vulnerabilities.

--- a/passive/SameSiteFinder/SameSiteFinder.json
+++ b/passive/SameSiteFinder/SameSiteFinder.json
@@ -1,0 +1,91 @@
+{
+  "description": "Extracts the names of issued cookies and their SameSite attributes to help identify entry points for CSRF vulnerabilities.",
+  "edition": 2,
+  "graph": {
+    "edges": [
+      {
+        "source": {
+          "exec_alias": "exec",
+          "node_id": 3
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 2
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "exec",
+          "node_id": 2
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 1
+        }
+      }
+    ],
+    "nodes": [
+      {
+        "alias": "passive_end",
+        "definition_id": "caido/passive-end",
+        "display": {
+          "x": -10,
+          "y": 310
+        },
+        "id": 1,
+        "inputs": [],
+        "name": "Passive End",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "javascript",
+        "definition_id": "caido/http-code-js",
+        "display": {
+          "x": -20,
+          "y": 150
+        },
+        "id": 2,
+        "inputs": [
+          {
+            "alias": "request",
+            "value": {
+              "data": "$on_intercept_response.request",
+              "kind": "ref"
+            }
+          },
+          {
+            "alias": "response",
+            "value": {
+              "data": "$on_intercept_response.response",
+              "kind": "ref"
+            }
+          },
+          {
+            "alias": "code",
+            "value": {
+              "data": "export async function run({ request, response }, sdk) {\n  const reqID = request.getId();\n  const host = request.getHost();\n  const headers = response.getHeaders();\n  const cookies = Object.keys(headers)\n    .filter(key => key.toLowerCase() === 'set-cookie')\n    .flatMap(key => headers[key]);\n\n  let description = \"\";\n\n  if (cookies.length > 0) {\n    description += `[+] Cookies have been issued by ${host} (ID=${reqID})\\n`;\n\n    const maxCookieKeyLength = Math.max(...cookies.map(cookie => cookie.split('=')[0].trim().length));\n\n    for (const cookie of cookies) {\n      let sameSitePolicy = \"Lax (attribute is not set)\";\n      const cookieKey = cookie.split('=')[0].trim();\n\n      const sameSiteMatch = cookie.match(/SameSite=(\\w+)/);\n      if (sameSiteMatch && sameSiteMatch[1]) {\n        sameSitePolicy = sameSiteMatch[1];\n      }\n\n      description += `Cookie name : ${cookieKey.padEnd(maxCookieKeyLength)}\\t(SameSite = ${sameSitePolicy})\\n`;\n    }\n\n    let finding = {\n      title: \"Cookies Issued\",\n      description: description.trim(),\n      reporter: \"SameSiteFinder\",\n      request: request\n    };\n    await sdk.findings.create(finding);\n  }\n}",
+              "kind": "string"
+            }
+          }
+        ],
+        "name": "Javascript",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "on_intercept_response",
+        "definition_id": "caido/on-intercept-response",
+        "display": {
+          "x": -30,
+          "y": -20
+        },
+        "id": 3,
+        "inputs": [],
+        "name": "On Intercept Response",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  "id": "d667a729-9f06-4519-83cb-aec265717aeb",
+  "kind": "passive",
+  "name": "SameSiteFinder"
+}


### PR DESCRIPTION
Extract and log the SameSite attribute, which is essential to check when looking for CSRF vulnerabilities. This can help users who have to test for a large number of vulnerabilities to stay on top of them.

![test](https://github.com/user-attachments/assets/c1f89c79-9963-49ef-b07d-8fc927cb7fa3)


---
Please ensure your pull request adheres to the following guidelines:

- [x] Follow the same folder structure as other workflows (see [template](https://github.com/caido/workflows/tree/main/Workflow%20Template)).
- [x] Has a proper author name and workflow description.
- [x] If using compiled code in JS Nodes, provide the source code for each.
- [x] If using a 3rd party library, include its license as a comment in the source code.

Thanks for contributing!
