### PR TITLE
Workflow improvements

### DIFF
--- a/packages/workflows/src/content-length-mismatch/javascript.ts
+++ b/packages/workflows/src/content-length-mismatch/javascript.ts
@@ -4,10 +4,13 @@
  * @returns {MaybePromise<Data | undefined>}
  */
 export async function run({ request, response }, sdk) {
+  // HEAD responses have no body but will have content-length header
+  if(response && request.getMethod() != "HEAD"){
     let realLength = response.getBody().toRaw().length;
-    let headers = response.getHeaders();
-    if (headers['Content-Length'] !== undefined && Number(headers['Content-Length']) !== realLength) {
-      let description = `The Content-Length header is set to ${headers['Content-Length']} but the actual content length is ${realLength}`;
+    let headers = response.getHeader('Content-Length');
+
+    if (headers !== undefined && headers.length>0 && Number(headers[0]) !== realLength) {
+      let description = `The Content-Length header is set to ${headers[0]} but the actual content length is ${realLength}`;
       await sdk.findings.create({
         title: "Content-Length header does not match actual content length",
         description: description,
@@ -17,4 +20,4 @@ export async function run({ request, response }, sdk) {
       });
     }
   }
-  
+}

--- a/packages/workflows/src/cookie-reflection/javascript.ts
+++ b/packages/workflows/src/cookie-reflection/javascript.ts
@@ -5,28 +5,24 @@
  */
 export async function run({ request, response }, sdk) {
     if (request && response) {
-      // get cookie header value
-      // parse cookie header to get values
-      // check response for the cookie value (if length of cookie is > 5)
-      // create finding
       const cookie_header = request.getHeader('Cookie');
       if(cookie_header) {
         const split = cookie_header[0].split(";");
-        for(let i = 0; i < split.length; i++){
-          const split2 = split[i].split('=');
+        for(const cookie of split){
+          const split2 = cookie.split('=');
           const cookie_name = split2[0];
           const cookie_val = split2[1];
           if(cookie_val.length < 6){
+            // checking short cookie values like "false" would create many false positives
             continue;
           }
           if(response.getBody().toText().indexOf(cookie_val) != -1){
-            const description = `The request to ${request.getUrl()} has contains the value of cookie ${cookie_name}`;
             await sdk.findings.create({
-              title: "Cookie Value Reflected In Response",
-              description: description,
+              title: `Value "${cookie_val}" from cookie "${cookie_name}" is reflected`,
+              description: `The response from ${request.getUrl()} contains the value "${cookie_val}" which is also the value of the cookie "${cookie_name}"`,
               request: request,
               reporter: "CookieValueReflectedInResponse",
-              dedupeKey: description
+              dedupeKey: `cookie_reflect_${request.getUrl()}_${cookie_name}_${cookie_val}`
             });
           }
         }

--- a/packages/workflows/src/json-with-wrong-content-type/javascript.ts
+++ b/packages/workflows/src/json-with-wrong-content-type/javascript.ts
@@ -9,7 +9,8 @@ export async function run({ request, response }, sdk) {
         let contentTypeHeader = response.getHeader('Content-Type');
 
         if (body.startsWith('{') || body.startsWith('[')) {
-            if (!contentTypeHeader[0].startsWith('application/json')) {
+            // Regex to ignore application/json application/manifest+json 
+            if (!contentTypeHeader[0].match(/^application\/(\w*\+)?json/)) {
                 let description = `The content of response from ${request.getHost()}${request.getPath()} is probably JSON but the content type is not application/json`;
                 await sdk.findings.create({
                 title: "JSON Response Without JSON Content-Type",

--- a/packages/workflows/src/multiple-server-headers/javascript.ts
+++ b/packages/workflows/src/multiple-server-headers/javascript.ts
@@ -29,15 +29,25 @@ export async function run({ request, response }, sdk) {
     
     for(var server of serverheaders){
       if(server != seenServerValue){
-        let description = `Webserver ${host} returned a new server header: ${server}`;
-        sdk.console.log(description);
+        // Create finding for new server header
         await sdk.findings.create({
-          title: "ServerMulti",
-          description: description,
+          title: `New Server Header: ${server}`,
+          description: `Webserver ${host} returned a new server header: ${server}.`,
           request: request,
           reporter: "ServerMulti",
-          dedupeKey: description
+          dedupeKey: `server_multi_${host}_${server}`
         });
+
+        // Create finding for old server header now that we have multiple
+        if (seenServerValue != "undefined") {
+          await sdk.findings.create({
+            title: `New Server Header: ${seenServerValue}`,
+            description: `Webserver ${host} returned a new server header: ${seenServerValue}.`,
+            request: request,
+            reporter: "ServerMulti",
+            dedupeKey: `server_multi_${host}_${seenServerValue}`
+          });
+        }
       }
     }
   }

--- a/packages/workflows/src/owasptop25/javascript.ts
+++ b/packages/workflows/src/owasptop25/javascript.ts
@@ -35,13 +35,12 @@ export async function run({ request, response }, sdk) {
     if (request) {
       // query params
       const query_parts = request.getQuery().split('&');
-      for (let i = 0; i < query_parts.length; i++) {
-        const query_param = query_parts[i].split('=')[0];
+      for (const query_part of query_parts) {
+        const query_param = query_part.split('=')[0];
         if(param_names.has(query_param)){
-          const requestUrl = request.getUrl();
           const description = `The request to ${request.getHost()}${request.getPath()} has the query param ${query_param} which is in OWASP's top 25 vulnerable paramters`;
           await sdk.findings.create({
-            title: "Request with OWASP top 25 vuln parameter",
+            title: `OWASP top 25 vuln query parameter: ${query_param}`,
             description: description,
             request: request,
             reporter: "OWASPTop25VulnerableParameters",
@@ -53,23 +52,21 @@ export async function run({ request, response }, sdk) {
       const body_params = [];
       try {
         const body = request.getBody().toJson();
-        for (var key in body) {
+        for (const key in body) {
           body_params.push(key);
         }
       } catch {
         const body = request.getBody().toText();
         const body_parts = body.split('&');
-        for (let i = 0; i < body_parts.length; i++) {
-          body_params.push(body_parts[i].split('=')[0]);
+        for (const body_part of body_parts) {
+          body_params.push(body_part.split('=')[0]);
         }
       }
-      for (let i = 0; i < body_params.length; i++) {
-        const body_param = body_params[i];
+      for (const body_param of body_params) {
         if(param_names.has(body_param)){
-          const requestUrl = request.getUrl();
           const description = `The request to ${request.getHost()}${request.getPath()} has the body param ${body_param} which is in OWASP's top 25 vulnerable paramters`;
           await sdk.findings.create({
-            title: "Request with OWASP top 25 vuln parameter",
+            title: `OWASP top 25 vuln body parameter: ${body_param}`,
             description: description,
             request: request,
             reporter: "OWASPTop25VulnerableParameters",


### PR DESCRIPTION
I made some changes to the workflows I recently submitted
- improved the finding titles to include detail about the finding (easier to read through list without needing to click into each one)
- updated content-length mismatch to ignore HEAD responses (false positive match)
- updated content-length mismatch to use getHeader() instead of getHeaders() (support case insensitive header names)
- updated json content-type to ignore application/xyz+json (false positive match)
- updated multiple server headers workflow to make a finding for the first Server value as well once two have been detected