### PR TITLE
Patches for cookie-reflection and JSON-with-wrong-content-type

### DIFF
--- a/packages/workflows/src/cookie-reflection/javascript.ts
+++ b/packages/workflows/src/cookie-reflection/javascript.ts
@@ -22,7 +22,7 @@ export async function run({ request, response }, sdk) {
               description: `The response from ${request.getUrl()} contains the value "${cookie_val}" which is also the value of the cookie "${cookie_name}"`,
               request: request,
               reporter: "CookieValueReflectedInResponse",
-              dedupeKey: `cookie_reflect_${request.getUrl()}_${cookie_name}_${cookie_val}`
+              dedupeKey: `cookie_reflect_${request.getHost()}${request.getPath()()}_${cookie_name}_${cookie_val}`
             });
           }
         }

--- a/packages/workflows/src/json-with-wrong-content-type/javascript.ts
+++ b/packages/workflows/src/json-with-wrong-content-type/javascript.ts
@@ -11,14 +11,16 @@ export async function run({ request, response }, sdk) {
         if (body.startsWith('{') || body.startsWith('[')) {
             // Regex to ignore application/json application/manifest+json 
             if (!contentTypeHeader[0].match(/^application\/(\w*\+)?json/)) {
-                let description = `The content of response from ${request.getHost()}${request.getPath()} is probably JSON but the content type is not application/json`;
-                await sdk.findings.create({
-                title: "JSON Response Without JSON Content-Type",
-                description: description,
-                request: request,
-                reporter: "JSON Response Without JSON Content-Type",
-                dedupeKey: description
-                });
+                if (!contentTypeHeader[0].match(/^text\/(javascript|css)/)) {
+                    let description = `The content of response from ${request.getHost()}${request.getPath()} is probably JSON but the content type is not application/json`;
+                    await sdk.findings.create({
+                    title: "JSON Response Without JSON Content-Type",
+                    description: description,
+                    request: request,
+                    reporter: "JSON Response Without JSON Content-Type",
+                    dedupeKey: description
+                    });
+                }
             } 
         }
     }


### PR DESCRIPTION
JSON-with-wrong-content-type now ignores the Content-Types text/css and text/javascript as false positives

Cookie Reflection dedupe key is now on path instead of the full url to avoid multiple findings on effectively the same thing with different query values.