### PR TITLE
feat: http method checker workflow

### DIFF
--- a/packages/workflows/src/http-method-checker/README.md
+++ b/packages/workflows/src/http-method-checker/README.md
@@ -1,0 +1,16 @@
+# HTTP Method Checker
+
+## Author
+- **Name:** [Ads Dawson](https://github.com/GangGreenTemperTatum)
+
+## Description
+This workflow dynamically probes HTTP endpoints by sending an `OPTIONS` request to detect discrepancies between the HTTP methods advertised by the server and the method originally used. It helps identify misconfigured HTTP methods exposed on the target.
+
+## Features
+- Sends `OPTIONS` request to the same host and path as the original request.
+- Parses `Allow` and `Access-Control-Allow-Methods` headers.
+- Flags requests where the original HTTP method is not listed in the allowed methods.
+- Creates findings with detailed metadata for easier triage.
+
+## Usage
+Import this workflow into Caido and run it during your HTTP request analysis. It automatically sends the probe and generates findings if discrepancies are found.

--- a/packages/workflows/src/http-method-checker/definition.json
+++ b/packages/workflows/src/http-method-checker/definition.json
@@ -70,7 +70,7 @@
         "version": "0.1.0"
       },
       {
-        "alias": "options_probe",
+        "alias": "javascript",
         "definition_id": "caido/http-code-js",
         "display": {
           "x": -10,

--- a/packages/workflows/src/http-method-checker/definition.json
+++ b/packages/workflows/src/http-method-checker/definition.json
@@ -1,0 +1,172 @@
+{
+  "description": "Passively probes each proxied HTTP request with a subsequent HTTP OPTIONS request and reports when the OPTIONS response includes allowed methods beyond the original request method.",
+  "edition": 2,
+  "graph": {
+    "edges": [
+      {
+        "source": {
+          "exec_alias": "exec",
+          "node_id": 2
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 3
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "exec",
+          "node_id": 3
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 1
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "exec",
+          "node_id": 0
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 5
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "true",
+          "node_id": 5
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 2
+        }
+      }
+    ],
+    "nodes": [
+      {
+        "alias": "on_intercept_request",
+        "definition_id": "caido/on-intercept-request",
+        "display": {
+          "x": -10,
+          "y": -110
+        },
+        "id": 0,
+        "inputs": [],
+        "name": "On intercept request",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "passive_end",
+        "definition_id": "caido/passive-end",
+        "display": {
+          "x": -10,
+          "y": 260
+        },
+        "id": 1,
+        "inputs": [],
+        "name": "Passive End",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "options_probe",
+        "definition_id": "caido/http-code-js",
+        "display": {
+          "x": -10,
+          "y": 80
+        },
+        "id": 2,
+        "inputs": [
+          {
+            "alias": "request",
+            "value": {
+              "data": "$on_intercept_request.request",
+              "kind": "ref"
+            }
+          },
+          {
+            "alias": "code",
+            "value": {
+              "data": "export async function run({ request, response }, sdk) {\n  if (!request) return;\n\n  const orig = request.getMethod();\n  const spec = request.toSpec();\n  spec.setMethod(\"OPTIONS\");\n\n  // Send the dynamic OPTIONS probe to the same host/path\n  const probe = await sdk.requests.send(spec);\n\n  if (probe.response) {\n    const headers = probe.response.getHeaders();\n    const allow = headers[\"allow\"]?.[0] || \"\";\n    const cors = headers[\"access-control-allow-methods\"]?.[0] || \"\";\n    const methods = (allow || cors).split(/\\s*,\\s*/);\n\n    if (methods.length && !methods.includes(orig)) {\n      const dedupeKey = ${request.getHost()}|${request.getPath()}|${orig}|${methods.join(\",\")};\n      await sdk.findings.create({\n        title: \"Extraneous HTTP methods exposed\",\n        description: OPTIONS listed methods [${methods.join(\", \")}], original: ${orig},\n        request,\n        response: probe.response,\n        dedupeKey\n      });\n    }\n  }\n}",
+              "kind": "string"
+            }
+          }
+        ],
+        "name": "OPTIONS Request Probe",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "create_finding",
+        "definition_id": "caido/finding-create",
+        "display": {
+          "x": -10,
+          "y": 170
+        },
+        "id": 3,
+        "inputs": [
+          {
+            "alias": "title",
+            "value": {
+              "data": "Create Finding",
+              "kind": "string"
+            }
+          },
+          {
+            "alias": "reporter",
+            "value": {
+              "data": "HTTP Method Checker",
+              "kind": "string"
+            }
+          },
+          {
+            "alias": "dedupe_key",
+            "value": {
+              "data": "`${host}|${path}|${origMethod}|${allowHeader}`, ",
+              "kind": "string"
+            }
+          },
+          {
+            "alias": "request",
+            "value": {
+              "data": "$options_probe.data",
+              "kind": "ref"
+            }
+          },
+          {
+            "alias": "description",
+            "value": {
+              "data": "$options_probe.data",
+              "kind": "ref"
+            }
+          }
+        ],
+        "name": "Create Finding",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "in_scope",
+        "definition_id": "caido/in-scope",
+        "display": {
+          "x": -10,
+          "y": -10
+        },
+        "id": 5,
+        "inputs": [
+          {
+            "alias": "request",
+            "value": {
+              "data": "$on_intercept_request.request",
+              "kind": "ref"
+            }
+          }
+        ],
+        "name": "In Scope",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  "id": "ce244451-262d-4c01-89d0-358b8fc58a2b",
+  "kind": "passive",
+  "name": "HTTP Method Checker"
+}

--- a/packages/workflows/src/http-method-checker/definition.json
+++ b/packages/workflows/src/http-method-checker/definition.json
@@ -88,7 +88,7 @@
           {
             "alias": "code",
             "value": {
-              "data": "export async function run({ request, response }, sdk) {\n  if (!request) return;\n\n  const orig = request.getMethod();\n  const spec = request.toSpec();\n  spec.setMethod(\"OPTIONS\");\n\n  // Send the dynamic OPTIONS probe to the same host/path\n  const probe = await sdk.requests.send(spec);\n\n  if (probe.response) {\n    const headers = probe.response.getHeaders();\n    const allow = headers[\"allow\"]?.[0] || \"\";\n    const cors = headers[\"access-control-allow-methods\"]?.[0] || \"\";\n    const methods = (allow || cors).split(/\\s*,\\s*/);\n\n    if (methods.length && !methods.includes(orig)) {\n      const dedupeKey = ${request.getHost()}|${request.getPath()}|${orig}|${methods.join(\",\")};\n      await sdk.findings.create({\n        title: \"Extraneous HTTP methods exposed\",\n        description: OPTIONS listed methods [${methods.join(\", \")}], original: ${orig},\n        request,\n        response: probe.response,\n        dedupeKey\n      });\n    }\n  }\n}",
+              "data": "",
               "kind": "string"
             }
           }

--- a/packages/workflows/src/http-method-checker/javascript.ts
+++ b/packages/workflows/src/http-method-checker/javascript.ts
@@ -1,0 +1,33 @@
+/**
+ * @param {HttpInput} input
+ * @param {SDK} sdk
+ * @returns {MaybePromise<Data | undefined>}
+ */
+export async function run({ request, response }, sdk) {
+  if (!request) return;
+
+  const orig = request.getMethod();
+  const spec = request.toSpec();
+  spec.setMethod("OPTIONS");
+
+  // Send the dynamic OPTIONS probe to the same host/path
+  const probe = await sdk.requests.send(spec);
+
+  if (probe.response) {
+    const headers = probe.response.getHeaders();
+    const allow = headers["allow"]?.[0] || "";
+    const cors = headers["access-control-allow-methods"]?.[0] || "";
+    const methods = (allow || cors).split(/\s*,\s*/);
+
+    if (methods.length && !methods.includes(orig)) {
+      const dedupeKey = `${request.getHost()}|${request.getPath()}|${orig}|${methods.join(",")}`;
+      await sdk.findings.create({
+        title: "Extraneous HTTP methods exposed",
+        description: `OPTIONS listed methods [${methods.join(", ")}], original: ${orig}`,
+        request,
+        response: probe.response,
+        dedupeKey
+      });
+    }
+  }
+}

--- a/packages/workflows/src/http-method-checker/manifest.json
+++ b/packages/workflows/src/http-method-checker/manifest.json
@@ -1,0 +1,10 @@
+{
+  "author": {
+    "name": "Ads Dawson"
+  },
+  "url": "https://github.com/caido-community/workflows/packages/workflows/http-method-checker/README.md",
+  "description": "Detects HTTP methods exposed by dynamically probing endpoints with OPTIONS requests.",
+  "id": "http-method-checker",
+  "name": "HTTP Method Checker",
+  "version": "0.1.0"
+}


### PR DESCRIPTION
# http method checker workflow

- [x] Follow the same folder structure as other workflows (see [template](https://github.com/caido/workflows/tree/main/Workflow%20Template)).
- [x] Has a proper author name and workflow description.
- [ ] If using compiled code in JS Nodes, provide the source code for each.
- [ ] If using a 3rd party library, include its license as a comment in the source code.

This change introduces an asynchronous function run designed to perform a dynamic security check against an HTTP endpoint by probing its supported HTTP methods via an `OPTIONS` request.

### Detailed Behavior:

The function accepts an input context containing the original HTTP request and a response handler, along with an SDK instance for sending requests and creating findings.
- It immediately returns if no request is provided.
- It extracts the original HTTP method of the incoming request (orig).
- A clone of the original request’s specification is created (spec), with its method forcibly set to `OPTIONS`.
- Using the SDK, it sends this modified `OPTIONS` request (probe) to the same host and path as the original request.
- Upon receiving a response to the `OPTIONS` probe, it inspects the headers for allowed HTTP methods from either the `Allow` or `Access-Control-Allow-Methods` headers.

The allowed methods are parsed and compared against the original request method.

If the original method is not included in the allowed methods list returned by the server, the function creates a finding via the SDK, flagging the discrepancy as "Extraneous HTTP methods exposed."

The finding includes a descriptive message, the original request, the probe response, and a deduplication key to avoid duplicate reports.

### Deduplication Key:

The deduplication key is constructed as:

```javascript
`${host}|${path}|${origMethod}|${allowHeader}`
```

- `host` is the request host,
- `path` is the request path,
- `origMethod` is the original HTTP method of the request,
- `allowHeader` is the raw value from the Allow or Access-Control-Allow-Methods header.

This key ensures unique identification of discrepancies per endpoint and method mismatch, preventing redundant findings.

### Example Report:

**Title**: Extraneous HTTP methods exposed
**Description**: OPTIONS listed methods [GET, POST, PUT], original: DELETE
**Host**: example.com
**Path**: /api/resource
**Original Method**: DELETE
**Allowed Methods**: GET, POST, PUT

Deduplication Key: `example.com|/api/resource|DELETE|GET,POST,PUT`

This report indicates that the original HTTP method (`DELETE`) is not advertised as allowed by the server’s `OPTIONS` response, highlighting a potential security or configuration issue.
