### PR TITLE
chore: update leakz workflow to in scope

### DIFF
--- a/packages/workflows/src/leakz/definition.json
+++ b/packages/workflows/src/leakz/definition.json
@@ -15,12 +15,32 @@
       },
       {
         "source": {
+          "exec_alias": "false",
+          "node_id": 4
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 1
+        }
+      },
+      {
+        "source": {
+          "exec_alias": "true",
+          "node_id": 4
+        },
+        "target": {
+          "exec_alias": "exec",
+          "node_id": 2
+        }
+      },
+      {
+        "source": {
           "exec_alias": "exec",
           "node_id": 3
         },
         "target": {
           "exec_alias": "exec",
-          "node_id": 2
+          "node_id": 4
         }
       }
     ],
@@ -69,6 +89,26 @@
           }
         ],
         "name": "Leakz",
+        "version": "0.1.0"
+      },
+      {
+        "alias": "in_scope",
+        "definition_id": "caido/in-scope",
+        "display": {
+          "x": 0,
+          "y": 85
+        },
+        "id": 4,
+        "inputs": [
+          {
+            "alias": "request",
+            "value": {
+              "data": "$on_intercept_response.request",
+              "kind": "ref"
+            }
+          }
+        ],
+        "name": "In Scope",
         "version": "0.1.0"
       },
       {


### PR DESCRIPTION
small refactor to existing workflow `leakz` which ensures in-scope is mandatory matched

tested:

<img width="1350" height="808" alt="image" src="https://github.com/user-attachments/assets/b40e777f-b97e-4c72-a504-bf4c173e745f" />

[related Discord thread](https://discord.com/channels/843915806748180492/1237827511463972884/1416374798183038986)